### PR TITLE
socket_shutdown should stop read and write

### DIFF
--- a/sock/SocketClient.php
+++ b/sock/SocketClient.php
@@ -38,7 +38,7 @@ class SocketClient {
 	}
 	
 	public function close() {
-		socket_shutdown( $this->connection, 0);
+		socket_shutdown( $this->connection );
 		socket_close( $this->connection );
 	}
 }


### PR DESCRIPTION
As we are closing this connection on the next line, socket_shutdown should stop reading _and_ writing. Removed additional parameter to reflect default PHP behaviour.
